### PR TITLE
Brought the conceptItems in line with the newsItems

### DIFF
--- a/newsml/conceptitem/conceptitem-abstract.xml
+++ b/newsml/conceptitem/conceptitem-abstract.xml
@@ -3,32 +3,60 @@
     version="1" standard="NewsML-G2" standardversion="2.20" conformance="power">
     <!-- catalog for ninat:, nprov:, irel:, cpnat:, drol:, etc... -->
     <catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_27.xml"/>
-    
+
     <!-- catalog for infomaker extensions: imchn, imext etc... -->
     <catalogRef href="http://infomaker.se/spec/catalog/catalog.infomaker.g2.1_0.xml"/>
-    
+
     <itemMeta>
         <itemClass qcode="cinat:concept"/>
-        
+
         <!-- The party (person or organisation) responsible for the management of the Item. -->
-        <provider literal="XYZ"/>
-        
+        <provider literal="John Doe"/>
+
         <versionCreated>2015-08-11T07:30:42Z</versionCreated>
         <firstCreated>2015-08-11T07:30:42Z</firstCreated>
-        
+
         <!-- The publishing status of the Item, its value is "usable" by default. -->
         <pubStatus qcode="stat:usable"/>
-        
+
         <!-- TODO: Denna kanske vi kan ta bort förutsatt att den alltid är samma som <name> nedan -->
-        <!--<title>Hedemora</title>-->
+        <title>Hedemora</title>
 
         <!-- Extension used to map concept to x-im/category -->
         <itemMetaExtProperty type="imext:type" value="x-im/category"/>
+
+        <itemMetaExtProperty type="imext:uri" value="x-im://d72eb011-1552-4af4-8d15-cd4f8c157a87"/>
+
+        <links xmlns="http://www.infomaker.se/newsml/1.0">
+          <link title="John Doe" rel="creator" type="x-im/user"
+              uuid="9e1653f3-7575-4cb7-9b74-dc4dea63513e">
+              <data>
+                  <email>john.doe@example.org</email>
+                  <altId>58456</altId>
+              </data>
+          </link>
+          <link rel="irel:seeAlso" type="text/html" url="http://example.org/hedemora">
+          </link>
+          <link title="Dalarna" rel="broader" type="x-im/category"
+            uuid="230efee7-0b68-4b39-8840-7859a62ee904">
+            <data>
+              <qcode>imcpt:230efee7-0b68-4b39-8840-7859a62ee904</qcode>
+            </data>
+          </link>
+          <link title="Musikinstrument" rel="same-as" type="x-im/mediatopic"
+            uri="http://cv.iptc.org/newscodes/mediatopic/20000019"
+            uuid="4a89318f-1f05-5a95-bfb9-1014ac7fe71a">
+            <data>
+              <qcode>medtop:15078231</qcode>
+            </data>
+          </link>
+        </links>
     </itemMeta>
     <concept>
         <!-- Mandatory. @qcode or @uri must be used -->
-        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:d72eb011-1552-4af4-8d15-cd4f8c157a87"/>
-        
+        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:d72eb011-1552-4af4-8d15-cd4f8c157a87"
+          uri="x-im://d72eb011-1552-4af4-8d15-cd4f8c157a87" />
+
         <!-- Mandatory (for writer usage). Identifies the concept as an abstract which maps to "category" -->
         <type qcode="cpnat:abstract"/>
 
@@ -38,27 +66,29 @@
         <!-- Descriptions -->
         <definition role="drol:long">A long description...</definition>
         <definition role="drol:short">A short description</definition>
-        
+
         <!-- The full path for "category" -->
         <definition role="imrol:path">Allmänt/Dalarna/Hedemora</definition>
 
-        <!-- 
-            Additional information for the concept. If there are any related information to the 
-            concept it is represented as links (href) using the remoteContent 
+        <!--
+            Additional information for the concept. If there are any related information to the
+            concept it is represented as links (href) using the remoteContent
         -->
         <remoteInfo rel="irel:seeAlso" contenttype="text/html" href="http://example.org/hedemora"/>
-        
-        <!-- 
-            Parent to "category". 
-            
-            If using OC as a repository, relations could be built using broader/@qcode and 
+
+        <!--
+            Parent to "category".
+
+            If using OC as a repository, relations could be built using broader/@qcode and
             parent's conceptId/@qcode.
         -->
-        <broader qcode="imcpt:230efee7-0b68-4b39-8840-7859a62ee904">            
-            <name>Dalarna</name>            
+        <broader qcode="imcpt:230efee7-0b68-4b39-8840-7859a62ee904" type="cpnat:abstract">
+            <name>Dalarna</name>
         </broader>
 
         <!-- Can be used if one wishes to relate to other IPTC categories for example. -->
-        <sameAs type="cpnat:abstract" qcode="medtop:15078231"/>        
+        <sameAs type="cpnat:abstract" qcode="medtop:15078231">
+            <name>Musikinstrument</name>
+        </sameAs>
     </concept>
 </conceptItem>

--- a/newsml/conceptitem/conceptitem-object.xml
+++ b/newsml/conceptitem/conceptitem-object.xml
@@ -3,51 +3,66 @@
     version="1" standard="NewsML-G2" standardversion="2.20" conformance="power">
     <!-- catalog for ninat:, nprov:, irel:, cpnat:, drol:, etc... -->
     <catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_27.xml"/>
-    
+
     <!-- catalog for infomaker extensions: imchn, imext etc... -->
     <catalogRef href="http://infomaker.se/spec/catalog/catalog.infomaker.g2.1_0.xml"/>
-    
+
     <itemMeta>
         <itemClass qcode="cinat:concept"/>
-        
+
         <!-- The party (person or organisation) responsible for the management of the Item. -->
-        <provider literal="XYZ"/>
-        
+        <provider literal="John Doe"/>
+
         <versionCreated>2015-08-11T07:30:42Z</versionCreated>
         <firstCreated>2015-08-11T07:30:42Z</firstCreated>
-        
+
         <!-- The publishing status of the Item, its value is "usable" by default. -->
         <pubStatus qcode="stat:usable"/>
-        
+
         <!-- TODO: Denna kanske vi kan ta bort förutsatt att den alltid är samma som <name> nedan -->
-        <!--<title>Volvo</title>-->
-        
+        <title>Volvo</title>
+
         <!-- TODO: is "topic" correct for tags? -->
         <!-- Extension used to map concept to x-im/topic -->
         <itemMetaExtProperty type="imext:type" value="x-im/topic"/>
+
+        <itemMetaExtProperty type="imext:uri" value="x-im://b201e042-555b-11e5-885d-feff819cdc9f"/>
+
+        <links xmlns="http://www.infomaker.se/newsml/1.0">
+          <link title="John Doe" rel="creator" type="x-im/user"
+              uuid="9e1653f3-7575-4cb7-9b74-dc4dea63513e">
+              <data>
+                  <email>john.doe@example.org</email>
+                  <altId>58456</altId>
+              </data>
+          </link>
+          <link rel="irel:seeAlso" type="text/html" url="http://example.org/volvo">
+          </link>
+        </links>
     </itemMeta>
     <concept>
         <!-- Mandatory. @qcode or @uri must be used -->
-        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:b201e042-555b-11e5-885d-feff819cdc9f"/>
-        
+        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:b201e042-555b-11e5-885d-feff819cdc9f"
+          uri="x-im://b201e042-555b-11e5-885d-feff819cdc9f"/>
+
         <!-- TODO: is "topic" correct for tags? -->
         <!-- Mandatory (for writer usage). Identifies the concept as an abstract which maps to "topic" -->
         <type qcode="cpnat:object"/>
-        
+
         <!-- Mandatory. Name of concept -->
         <name>Volvo</name>
-        
+
         <!-- Descriptions -->
         <definition role="drol:long">A long description...</definition>
         <definition role="drol:short">A short description</definition>
-        
+
         <!-- The full path for "object" -->
         <definition role="imrol:path">Cars/Volvo</definition>
-                
-        <!-- 
-            Additional information for the concept. If there are any related information to the 
-            concept it is represented as links (href) using the remoteContent 
+
+        <!--
+            Additional information for the concept. If there are any related information to the
+            concept it is represented as links (href) using the remoteContent
         -->
-        <remoteInfo rel="irel:seeAlso" contenttype="text/html" href="http://example.org/volvo"/>        
+        <remoteInfo rel="irel:seeAlso" contenttype="text/html" href="http://example.org/volvo"/>
     </concept>
 </conceptItem>

--- a/newsml/conceptitem/conceptitem-place.xml
+++ b/newsml/conceptitem/conceptitem-place.xml
@@ -3,54 +3,69 @@
     version="1" standard="NewsML-G2" standardversion="2.20" conformance="power">
     <!-- catalog for ninat:, nprov:, irel:, cpnat:, drol:, etc... -->
     <catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_27.xml"/>
-    
+
     <!-- catalog for infomaker extensions: imchn, imext etc... -->
     <catalogRef href="http://infomaker.se/spec/catalog/catalog.infomaker.g2.1_0.xml"/>
-    
+
     <itemMeta>
         <itemClass qcode="cinat:concept"/>
-        
+
         <!-- The party (person or organisation) responsible for the management of the Item. -->
-        <provider literal="XYZ"/>
-        
+        <provider literal="John Doe"/>
+
         <versionCreated>2015-08-11T07:30:42Z</versionCreated>
         <firstCreated>2015-08-11T07:30:42Z</firstCreated>
-        
+
         <!-- The publishing status of the Item, its value is "usable" by default. -->
         <pubStatus qcode="stat:usable"/>
-        
+
         <!-- TODO: Denna kanske vi kan ta bort förutsatt att den alltid är samma som <name> nedan -->
-        <!--<title>Alvesta</title>-->
-        
+        <title>Alvesta</title>
+
         <!-- Extension used to map concept to x-im/place -->
         <itemMetaExtProperty type="imext:type" value="x-im/place"/>
+
+        <itemMetaExtProperty type="imext:uri" value="x-im://bce38dda-555b-11e5-885d-feff819cdc9f"/>
+
+        <links xmlns="http://www.infomaker.se/newsml/1.0">
+          <link title="John Doe" rel="creator" type="x-im/user"
+              uuid="9e1653f3-7575-4cb7-9b74-dc4dea63513e">
+              <data>
+                  <email>john.doe@example.org</email>
+                  <altId>58456</altId>
+              </data>
+          </link>
+          <link rel="irel:seeAlso" type="text/html" url="http://example.org/alvesta">
+          </link>
+        </links>
     </itemMeta>
     <concept>
         <!-- Mandatory. @qcode or @uri must be used -->
-        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:bce38dda-555b-11e5-885d-feff819cdc9f"/>
-        
+        <conceptId created="2015-08-11T07:30:42Z" qcode="imcpt:bce38dda-555b-11e5-885d-feff819cdc9f"
+          uri="x-im://bce38dda-555b-11e5-885d-feff819cdc9f"/>
+
         <!-- Mandatory (for writer usage). Identifies the concept as an abstract which maps to "place" -->
         <type qcode="cpnat:poi"/>
-        
+
         <!-- Mandatory. Name of concept -->
         <name>Alvesta</name>
-        
+
         <!-- Descriptions -->
         <definition role="drol:long">A long description...</definition>
         <definition role="drol:short">A short description</definition>
-                
-        <!-- 
-            Additional information for the concept. If there are any related information to the 
-            concept it is represented as links (href) using the remoteContent 
+
+        <!--
+            Additional information for the concept. If there are any related information to the
+            concept it is represented as links (href) using the remoteContent
         -->
         <remoteInfo rel="irel:seeAlso" contenttype="text/html" href="http://example.org/alvesta"/>
 
-        <!-- 
+        <!--
             To represent geodata we are using WKT, for more info see
             https://en.wikipedia.org/wiki/Well-known_text.
         -->
         <metadata xmlns="http://www.infomaker.se/newsml/1.0">
-            <object type="x-im/place">
+            <object id="B1Lkp0OqQXo" type="x-im/place">
                 <data>
                     <position>POINT(14.55600 56.89921)</position>
                 </data>


### PR DESCRIPTION
I updated the conceptItems so that it uses links as bearers of the actual data payload for broader, creator sameAs et.c., just like how it's done for newsItems.

Please note that the `link@rel="same-as"` for the abstract concept item now refers to a real media topic with both a `@uri` and `@uuid` set. The `@uuid` is a v5 UUID based off the media topic URI, and this assumes that all (used) media topics are saved in OC using the same method for generating a deterministic UUID.

``` xml
<link title="Musikinstrument" rel="same-as" type="x-im/mediatopic"
  uri="http://cv.iptc.org/newscodes/mediatopic/20000019"
  uuid="4a89318f-1f05-5a95-bfb9-1014ac7fe71a">
  <data>
    <qcode>medtop:15078231</qcode>
  </data>
</link>
```
